### PR TITLE
Add advanced calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # acilis
-Son denemeler
+
+Bu depo, basit denemeler icin kullanilmaktadir.
+
+## Gelişmiş Hesap Makinesi
+
+`calculator.py` dosyasi, matematiksel ifadeleri degerlendirmek icin gelismis bir hesap makinesi saglar.
+
+### Kullanım
+
+```bash
+# Tek seferlik hesaplama
+python calculator.py "2 + 3 * 4"
+
+# Etkilesimli mod
+python calculator.py
+>>> sin(pi / 2)
+1.0
+```
+
+Desteklenen tum fonksiyonlar Python'in `math` modulunden saglanir.

--- a/calculator.py
+++ b/calculator.py
@@ -1,0 +1,45 @@
+import argparse
+import math
+
+allowed_names = {name: getattr(math, name) for name in dir(math) if not name.startswith("__")}
+
+# Add built-in constants
+allowed_names.update({"pi": math.pi, "e": math.e})
+
+
+def evaluate(expression: str):
+    """Safely evaluate a mathematical expression using math module functions."""
+    return eval(expression, {"__builtins__": {}}, allowed_names)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Advanced calculator")
+    parser.add_argument("expression", nargs="?", help="Expression to evaluate")
+    args = parser.parse_args()
+
+    if args.expression:
+        try:
+            result = evaluate(args.expression)
+            print(result)
+        except Exception as exc:
+            print(f"Error: {exc}")
+    else:
+        # Interactive mode
+        while True:
+            try:
+                expr = input(">>> ")
+            except (EOFError, KeyboardInterrupt):
+                print()
+                break
+            if expr.strip().lower() in {"exit", "quit"}:
+                break
+            if not expr.strip():
+                continue
+            try:
+                print(evaluate(expr))
+            except Exception as exc:
+                print(f"Error: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `calculator.py` for evaluating math expressions
- document calculator usage in README
- ignore Python cache files

## Testing
- `python -m py_compile calculator.py`
- `python calculator.py "2 + 3 * 4"`
- `python calculator.py <<'EOF'
2 + 2
sin(pi / 2)
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685896ecfb188320b6d21c239361305c